### PR TITLE
Add tests around AccessibilityServices

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,6 +7,10 @@ android {
         targetSdkVersion 23
     }
 
+    repositories {
+        jcenter()
+    }
+
     compileSdkVersion 23
     buildToolsVersion "22.0.1"
 }
@@ -25,4 +29,6 @@ publish {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -31,4 +31,5 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.1.1'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'com.squareup.assertj:assertj-android:1.1.0'
 }

--- a/core/src/main/java/com/novoda/accessibility/AccessibilityServices.java
+++ b/core/src/main/java/com/novoda/accessibility/AccessibilityServices.java
@@ -2,6 +2,7 @@ package com.novoda.accessibility;
 
 import android.accessibilityservice.AccessibilityServiceInfo;
 import android.content.Context;
+import android.support.annotation.VisibleForTesting;
 import android.view.accessibility.AccessibilityManager;
 
 import java.util.List;
@@ -15,7 +16,8 @@ public final class AccessibilityServices {
         return new AccessibilityServices(accessibilityManager);
     }
 
-    private AccessibilityServices(AccessibilityManager accessibilityManager) {
+    @VisibleForTesting
+    AccessibilityServices(AccessibilityManager accessibilityManager) {
         this.accessibilityManager = accessibilityManager;
     }
 

--- a/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
+++ b/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
@@ -3,6 +3,8 @@ package com.novoda.accessibility;
 import android.accessibilityservice.AccessibilityServiceInfo;
 import android.view.accessibility.AccessibilityManager;
 
+import com.novoda.accessibility.ClosedCaptionManagerFactory.CaptionManager;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -23,12 +25,15 @@ public class AccessibilityServicesTest {
     @Mock
     AccessibilityServiceInfo mockAccessibilityServiceInfo;
 
+    @Mock
+    CaptionManager mockCaptionManager;
+
     private AccessibilityServices accessibilityServices;
 
     @Before
     public void setUp() {
         initMocks(this);
-        accessibilityServices = new AccessibilityServices(mockAccessibilityManager);
+        accessibilityServices = new AccessibilityServices(mockAccessibilityManager, mockCaptionManager);
     }
 
     @Test

--- a/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
+++ b/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
@@ -46,4 +46,14 @@ public class AccessibilityServicesTest {
         assertThat(spokenFeedbackEnabled).isTrue();
     }
 
+    @Test
+    public void whenAccessibilityServiceInfoListIsEmpty_thenSpokenFeedbackIsDisabled() {
+        when(mockAccessibilityManager.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_SPOKEN))
+                .thenReturn(Collections.<AccessibilityServiceInfo>emptyList());
+
+        boolean spokenFeedbackEnabled = accessibilityServices.isSpokenFeedbackEnabled();
+
+        assertThat(spokenFeedbackEnabled).isFalse();
+    }
+
 }

--- a/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
+++ b/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
@@ -13,7 +13,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -39,7 +38,8 @@ public class AccessibilityServicesTest {
     @Test
     public void whenAccessibilityServiceInfoListIsNotEmpty_thenSpokenFeedbackIsEnabled() {
         List<AccessibilityServiceInfo> serviceInfoList = Collections.singletonList(mockAccessibilityServiceInfo);
-        when(mockAccessibilityManager.getEnabledAccessibilityServiceList(anyInt())).thenReturn(serviceInfoList);
+        when(mockAccessibilityManager.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_SPOKEN))
+                .thenReturn(serviceInfoList);
 
         boolean spokenFeedbackEnabled = accessibilityServices.isSpokenFeedbackEnabled();
 

--- a/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
+++ b/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
@@ -1,0 +1,44 @@
+package com.novoda.accessibility;
+
+import android.accessibilityservice.AccessibilityServiceInfo;
+import android.view.accessibility.AccessibilityManager;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class AccessibilityServicesTest {
+
+    @Mock
+    AccessibilityManager mockAccessibilityManager;
+
+    @Mock
+    AccessibilityServiceInfo mockAccessibilityServiceInfo;
+
+    private AccessibilityServices accessibilityServices;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        accessibilityServices = new AccessibilityServices(mockAccessibilityManager);
+    }
+
+    @Test
+    public void whenAccessibilityServiceInfoListIsNotEmpty_thenSpokenFeedbackIsEnabled() {
+        List<AccessibilityServiceInfo> serviceInfoList = Collections.singletonList(mockAccessibilityServiceInfo);
+        when(mockAccessibilityManager.getEnabledAccessibilityServiceList(anyInt())).thenReturn(serviceInfoList);
+
+        boolean spokenFeedbackEnabled = accessibilityServices.isSpokenFeedbackEnabled();
+
+        assertThat(spokenFeedbackEnabled).isTrue();
+    }
+
+}


### PR DESCRIPTION
This PR adds tests (and required dependencies) around the `AccessibilityServices` class. As soon as #1 is merged and this one too we'll be adding more tests around the captioning manager.

Paired with @jackSzm.
