### PR TITLE
Remove final so we can mock accessibility services (easily)

### DIFF
--- a/core/src/main/java/com/novoda/accessibility/AccessibilityServices.java
+++ b/core/src/main/java/com/novoda/accessibility/AccessibilityServices.java
@@ -9,7 +9,7 @@ import com.novoda.accessibility.ClosedCaptionManagerFactory.CaptionManager;
 
 import java.util.List;
 
-public final class AccessibilityServices {
+public class AccessibilityServices {
 
     private final AccessibilityManager accessibilityManager;
     private final CaptionManager captionManager;


### PR DESCRIPTION
In order to test some client classes (outside of the library) we nee to mock `AccessibilityServices`, so we need to not have this class as `final`. An alternative would be to provide a test version of the library so it's swapped in as a test-only dependency.

Paired with @jackSzm.
