### PR TITLE
Add option for a title-less dialog

### DIFF
--- a/core/src/main/java/com/novoda/accessibility/ActionsAlertDialogCreator.java
+++ b/core/src/main/java/com/novoda/accessibility/ActionsAlertDialogCreator.java
@@ -7,6 +7,8 @@ import android.support.v7.app.AlertDialog;
 
 public class ActionsAlertDialogCreator {
 
+    private static final int NO_TITLE = 0;
+    
     private final Context context;
 
     @StringRes
@@ -14,29 +16,37 @@ public class ActionsAlertDialogCreator {
 
     private final Actions actions;
 
-    public ActionsAlertDialogCreator(Context context, int title, Actions actions) {
+    public ActionsAlertDialogCreator(Context context, Actions actions) {
+        this(context, NO_TITLE, actions);
+    }
+
+    public ActionsAlertDialogCreator(Context context, @StringRes int title, Actions actions) {
         this.context = context;
         this.title = title;
         this.actions = actions;
     }
 
     public AlertDialog create() {
-        return new AlertDialog.Builder(context)
-                .setTitle(title)
-                .setItems(
-                        collateActionLabels(),
-                        new DialogInterface.OnClickListener() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        builder.setItems(
+                collateActionLabels(),
+                new DialogInterface.OnClickListener() {
 
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                Action action = actions.getAction(which);
-                                action.run();
-                                dialog.dismiss();
-                            }
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        Action action = actions.getAction(which);
+                        action.run();
+                        dialog.dismiss();
+                    }
 
-                        }
-                )
-                .create();
+                }
+        );
+
+        if (title != 0) {
+            builder.setTitle(title);
+        }
+
+        return builder.create();
     }
 
     private CharSequence[] collateActionLabels() {

--- a/core/src/main/java/com/novoda/accessibility/ActionsAlertDialogCreator.java
+++ b/core/src/main/java/com/novoda/accessibility/ActionsAlertDialogCreator.java
@@ -42,7 +42,7 @@ public class ActionsAlertDialogCreator {
                 }
         );
 
-        if (title != 0) {
+        if (title != NO_TITLE) {
             builder.setTitle(title);
         }
 

--- a/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
+++ b/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
@@ -53,7 +53,7 @@ public class TweetView extends LinearLayout {
     }
 
     private void setClickListenerToShowDialogFor(final Actions actions) {
-        setButtonsAsClickableFalseToFixErrorOnLollipopPlus();
+        setButtonsAsClickableFalseToFixBehaviorChangeOnLollipopPlus();
 
         setOnClickListener(
                 new OnClickListener() {
@@ -65,7 +65,7 @@ public class TweetView extends LinearLayout {
         );
     }
 
-    private void setButtonsAsClickableFalseToFixErrorOnLollipopPlus() {
+    private void setButtonsAsClickableFalseToFixBehaviorChangeOnLollipopPlus() {
         // https://code.google.com/p/android/issues/detail?id=205431
         replyButton.setClickable(false);
         retweetButton.setClickable(false);

--- a/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
+++ b/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.support.v4.view.ViewCompat;
 import android.util.AttributeSet;
 import android.view.View;
-import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -20,8 +19,8 @@ import java.util.Arrays;
 public class TweetView extends LinearLayout {
 
     private TextView tweetTextView;
-    private Button replyButton;
-    private Button retweetButton;
+    private View replyButton;
+    private View retweetButton;
     private AccessibilityServices services;
 
     public TweetView(Context context, AttributeSet attrs) {
@@ -36,8 +35,8 @@ public class TweetView extends LinearLayout {
 
         View.inflate(getContext(), R.layout.merge_tweet, this);
         tweetTextView = (TextView) findViewById(R.id.tweet_text);
-        replyButton = (Button) findViewById(R.id.tweet_button_reply);
-        retweetButton = (Button) findViewById(R.id.tweet_button_retweet);
+        replyButton = findViewById(R.id.tweet_button_reply);
+        retweetButton = findViewById(R.id.tweet_button_retweet);
     }
 
     public void display(final String tweet, final Listener listener) {
@@ -46,15 +45,38 @@ public class TweetView extends LinearLayout {
 
         tweetTextView.setText(tweet);
 
+        if (services.isSpokenFeedbackEnabled()) {
+            setClickListenerToShowDialogFor(actions);
+        } else {
+            setIndividualClickListeners(tweet, listener);
+        }
+    }
+
+    private void setClickListenerToShowDialogFor(final Actions actions) {
+        setButtonsAsClickableFalseToFixErrorOnLollipopPlus();
+
         setOnClickListener(
                 new OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        if (services.isSpokenFeedbackEnabled()) {
-                            showAlertDialogFor(actions);
-                        } else {
-                            listener.onClick(tweet);
-                        }
+                        showAlertDialogFor(actions);
+                    }
+                }
+        );
+    }
+
+    private void setButtonsAsClickableFalseToFixErrorOnLollipopPlus() {
+        // https://code.google.com/p/android/issues/detail?id=205431
+        replyButton.setClickable(false);
+        retweetButton.setClickable(false);
+    }
+
+    private void setIndividualClickListeners(final String tweet, final Listener listener) {
+        setOnClickListener(
+                new OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        listener.onClick(tweet);
                     }
                 }
         );
@@ -81,19 +103,22 @@ public class TweetView extends LinearLayout {
     private Actions createActions(final String tweet, final Listener listener) {
         return new Actions(
                 Arrays.asList(
-                        new Action(R.id.tweet_action_open, R.string.tweet_action_open, new Runnable() {
+                        new Action(
+                                R.id.tweet_action_open, R.string.tweet_action_open, new Runnable() {
                             @Override
                             public void run() {
                                 listener.onClick(tweet);
                             }
                         }),
-                        new Action(R.id.tweet_action_reply, R.string.tweet_action_reply, new Runnable() {
+                        new Action(
+                                R.id.tweet_action_reply, R.string.tweet_action_reply, new Runnable() {
                             @Override
                             public void run() {
                                 listener.onClickReply(tweet);
                             }
                         }),
-                        new Action(R.id.tweet_action_retweet, R.string.tweet_action_retweet, new Runnable() {
+                        new Action(
+                                R.id.tweet_action_retweet, R.string.tweet_action_retweet, new Runnable() {
                             @Override
                             public void run() {
                                 listener.onClickRetweet(tweet);


### PR DESCRIPTION
## Problem

It could be kind of annoying to have the title read out every time you open an item.
## Solution

This PR makes the title optional.
## Tests

No, but I'm happy to add some if someone has suggestions on the best way to test this, if they think it should be tested.
## Other

I separated the click listeners for when spoken feedback is enabled and when it is not enabled for clarity.
## TODO

Removing the title is all well and good but it does reduce context - what if you could a custom message when the view is focused? Instead of "Double-tap to select" it might say "Double-tap for actions"? whaaaaat.
## Paired with

@xrigau 
