### PR TITLE
Add custom usage hints to ActionsAccessibilityDelegate

### DIFF
--- a/core/src/main/java/com/novoda/accessibility/ActionsAccessibilityDelegate.java
+++ b/core/src/main/java/com/novoda/accessibility/ActionsAccessibilityDelegate.java
@@ -18,24 +18,22 @@ public class ActionsAccessibilityDelegate extends AccessibilityDelegateCompat {
     private final Actions actions;
 
     @StringRes
-    private final int customClickLabel;
+    private int clickLabel = NO_CUSTOM_LABEL;
 
     @StringRes
-    private final int customLongClickLabel;
+    private int longClickLabel = NO_CUSTOM_LABEL;
 
     public ActionsAccessibilityDelegate(Resources resources, Actions actions) {
-        this(resources, actions, NO_CUSTOM_LABEL);
-    }
-
-    public ActionsAccessibilityDelegate(Resources resources, Actions actions, @StringRes int customClickLabel) {
-        this(resources, actions, customClickLabel, NO_CUSTOM_LABEL);
-    }
-
-    public ActionsAccessibilityDelegate(Resources resources, Actions actions, @StringRes int customClickLabel, @StringRes int customLongClickLabel) {
         this.resources = resources;
         this.actions = actions;
-        this.customClickLabel = customClickLabel;
-        this.customLongClickLabel = customLongClickLabel;
+    }
+
+    public void setClickLabel(@StringRes int clickLabel) {
+        this.clickLabel = clickLabel;
+    }
+
+    public void setLongClickLabel(@StringRes int longClickLabel) {
+        this.longClickLabel = longClickLabel;
     }
 
     @Override
@@ -51,20 +49,20 @@ public class ActionsAccessibilityDelegate extends AccessibilityDelegateCompat {
     }
 
     private void addCustomDescriptionForClickEventIfNecessary(View host, AccessibilityNodeInfoCompat info) {
-        if (!host.isClickable() || customClickLabel == NO_CUSTOM_LABEL) {
+        if (!host.isClickable() || clickLabel == NO_CUSTOM_LABEL) {
             return;
         }
 
-        String customClickLabelText = resources.getString(customClickLabel);
+        String customClickLabelText = resources.getString(clickLabel);
         info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_CLICK, customClickLabelText));
     }
 
     private void addCustomDescriptionForLongClickEventIfNecessary(View host, AccessibilityNodeInfoCompat info) {
-        if (!host.isLongClickable() || customLongClickLabel == NO_CUSTOM_LABEL) {
+        if (!host.isLongClickable() || longClickLabel == NO_CUSTOM_LABEL) {
             return;
         }
 
-        String customLongClickLabelText = resources.getString(customLongClickLabel);
+        String customLongClickLabelText = resources.getString(longClickLabel);
         info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_LONG_CLICK, customLongClickLabelText));
     }
 

--- a/core/src/main/java/com/novoda/accessibility/ActionsAccessibilityDelegate.java
+++ b/core/src/main/java/com/novoda/accessibility/ActionsAccessibilityDelegate.java
@@ -2,18 +2,40 @@ package com.novoda.accessibility;
 
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.support.annotation.StringRes;
 import android.support.v4.view.AccessibilityDelegateCompat;
 import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat;
 import android.view.View;
 
+import static android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.ACTION_CLICK;
+import static android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.ACTION_LONG_CLICK;
+
 public class ActionsAccessibilityDelegate extends AccessibilityDelegateCompat {
+
+    private static final int NO_CUSTOM_LABEL = 0;
 
     private final Resources resources;
     private final Actions actions;
 
+    @StringRes
+    private final int customClickLabel;
+
+    @StringRes
+    private final int customLongClickLabel;
+
     public ActionsAccessibilityDelegate(Resources resources, Actions actions) {
+        this(resources, actions, NO_CUSTOM_LABEL);
+    }
+
+    public ActionsAccessibilityDelegate(Resources resources, Actions actions, @StringRes int customClickLabel) {
+        this(resources, actions, customClickLabel, NO_CUSTOM_LABEL);
+    }
+
+    public ActionsAccessibilityDelegate(Resources resources, Actions actions, @StringRes int customClickLabel, @StringRes int customLongClickLabel) {
         this.resources = resources;
         this.actions = actions;
+        this.customClickLabel = customClickLabel;
+        this.customLongClickLabel = customLongClickLabel;
     }
 
     @Override
@@ -23,6 +45,27 @@ public class ActionsAccessibilityDelegate extends AccessibilityDelegateCompat {
             String label = resources.getString(action.getLabel());
             info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(action.getId(), label));
         }
+
+        addCustomDescriptionForClickEventIfNecessary(host, info);
+        addCustomDescriptionForLongClickEventIfNecessary(host, info);
+    }
+
+    private void addCustomDescriptionForClickEventIfNecessary(View host, AccessibilityNodeInfoCompat info) {
+        if (!host.isClickable() || customClickLabel == NO_CUSTOM_LABEL) {
+            return;
+        }
+
+        String customClickLabelText = resources.getString(customClickLabel);
+        info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_CLICK, customClickLabelText));
+    }
+
+    private void addCustomDescriptionForLongClickEventIfNecessary(View host, AccessibilityNodeInfoCompat info) {
+        if (!host.isLongClickable() || customLongClickLabel == NO_CUSTOM_LABEL) {
+            return;
+        }
+
+        String customLongClickLabelText = resources.getString(customLongClickLabel);
+        info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_LONG_CLICK, customLongClickLabelText));
     }
 
     @Override

--- a/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
+++ b/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
@@ -42,7 +42,7 @@ public class TweetView extends LinearLayout {
 
     public void display(final String tweet, final Listener listener) {
         final Actions actions = createActions(tweet, listener);
-        ViewCompat.setAccessibilityDelegate(this, new ActionsAccessibilityDelegate(getResources(), actions));
+        ViewCompat.setAccessibilityDelegate(this, new ActionsAccessibilityDelegate(getResources(), actions, R.string.tweet_actions_usage_hint));
 
         tweetTextView.setText(tweet);
 

--- a/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
+++ b/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
@@ -42,7 +42,9 @@ public class TweetView extends LinearLayout {
 
     public void display(final String tweet, final Listener listener) {
         final Actions actions = createActions(tweet, listener);
-        ViewCompat.setAccessibilityDelegate(this, new ActionsAccessibilityDelegate(getResources(), actions, R.string.tweet_actions_usage_hint));
+        ActionsAccessibilityDelegate delegate = new ActionsAccessibilityDelegate(getResources(), actions);
+        delegate.setClickLabel(R.string.tweet_actions_usage_hint);
+        ViewCompat.setAccessibilityDelegate(this, delegate);
 
         tweetTextView.setText(tweet);
 

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -9,6 +9,9 @@
   <string name="tweet_action_open">Open detail</string>
   <string name="tweet_action_reply">Reply</string>
   <string name="tweet_action_retweet">Retweet</string>
+
+  <!--The gesture prefix should not be necessary in description - it is a bug in the current version of TalkBack (4.1.1)-->
+  <!--TalkBack team ack this is a known issue and they will be fixing it to say "<interaction model> to <given description>"-->
   <string name="tweet_actions_usage_hint">Double-tap for actions</string>
 
 </resources>

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
+
   <string name="app_name">accessibility</string>
 
   <string name="tweet_button_reply">@string/tweet_action_reply</string>
@@ -8,4 +9,6 @@
   <string name="tweet_action_open">Open detail</string>
   <string name="tweet_action_reply">Reply</string>
   <string name="tweet_action_retweet">Retweet</string>
+  <string name="tweet_actions_usage_hint">Double-tap for actions</string>
+
 </resources>


### PR DESCRIPTION
# Problem

Default description for clickable views is not very descriptive - the user should have more context about the action that will be performed on click/on long click.
# Solution

Allow the client to supply a custom description.

This is the solution alluded to in the TODO of #7.
# Screenshots

| Before | After |
| --- | --- |
| ![before webm](https://cloud.githubusercontent.com/assets/2678555/14158087/2efa9cea-f6c6-11e5-8821-975c3e4d56d2.gif) | ![after webm](https://cloud.githubusercontent.com/assets/2678555/14158088/2efbe56e-f6c6-11e5-8234-97c152fadc05.gif) |

The demo has been updated to include a custom usage hint for the custom click action. There is a known bug in the current TalkBack (4.1.1) where it will not prefix the description with the gesture.

So clients of this library will have to update the string they pass when the TalkBack bug is fixed otherwise it will duplicate the gesture (e.g. the demo will say "Double-tap to double-tap for actions") - need to double check what the behaviour is on S-Voice.

Paired with no one.
