### PR TITLE
Add APIs to set usage hint labels with charsequence

### DIFF
--- a/core/src/main/java/com/novoda/accessibility/ActionsAccessibilityDelegate.java
+++ b/core/src/main/java/com/novoda/accessibility/ActionsAccessibilityDelegate.java
@@ -12,27 +12,50 @@ import static android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.
 
 public class ActionsAccessibilityDelegate extends AccessibilityDelegateCompat {
 
-    private static final int NO_CUSTOM_LABEL = 0;
-
     private final Resources resources;
     private final Actions actions;
 
-    @StringRes
-    private int clickLabel = NO_CUSTOM_LABEL;
-
-    @StringRes
-    private int longClickLabel = NO_CUSTOM_LABEL;
+    private CharSequence clickLabel = null;
+    private CharSequence longClickLabel = null;
 
     public ActionsAccessibilityDelegate(Resources resources, Actions actions) {
         this.resources = resources;
         this.actions = actions;
     }
 
+    /**
+     * Label describing the action that will be performed on click
+     *
+     * @param clickLabel
+     */
     public void setClickLabel(@StringRes int clickLabel) {
+        setClickLabel(resources.getString(clickLabel));
+    }
+
+    /**
+     * Label describing the action that will be performed on click
+     *
+     * @param clickLabel
+     */
+    public void setClickLabel(CharSequence clickLabel) {
         this.clickLabel = clickLabel;
     }
 
+    /**
+     * Label describing the action that will be performed on long click
+     *
+     * @param longClickLabel
+     */
     public void setLongClickLabel(@StringRes int longClickLabel) {
+        setLongClickLabel(resources.getString(longClickLabel));
+    }
+
+    /**
+     * Label describing the action that will be performed on long click
+     *
+     * @param longClickLabel
+     */
+    public void setLongClickLabel(CharSequence longClickLabel) {
         this.longClickLabel = longClickLabel;
     }
 
@@ -49,21 +72,19 @@ public class ActionsAccessibilityDelegate extends AccessibilityDelegateCompat {
     }
 
     private void addCustomDescriptionForClickEventIfNecessary(View host, AccessibilityNodeInfoCompat info) {
-        if (!host.isClickable() || clickLabel == NO_CUSTOM_LABEL) {
+        if (!host.isClickable() || clickLabel == null) {
             return;
         }
 
-        String customClickLabelText = resources.getString(clickLabel);
-        info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_CLICK, customClickLabelText));
+        info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_CLICK, clickLabel));
     }
 
     private void addCustomDescriptionForLongClickEventIfNecessary(View host, AccessibilityNodeInfoCompat info) {
-        if (!host.isLongClickable() || longClickLabel == NO_CUSTOM_LABEL) {
+        if (!host.isLongClickable() || longClickLabel == null) {
             return;
         }
 
-        String customLongClickLabelText = resources.getString(longClickLabel);
-        info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_LONG_CLICK, customLongClickLabelText));
+        info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_LONG_CLICK, longClickLabel));
     }
 
     @Override

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -10,8 +10,6 @@
   <string name="tweet_action_reply">Reply</string>
   <string name="tweet_action_retweet">Retweet</string>
 
-  <!--The gesture prefix should not be necessary in description - it is a bug in the current version of TalkBack (4.1.1)-->
-  <!--TalkBack team ack this is a known issue and they will be fixing it to say "<interaction model> to <given description>"-->
-  <string name="tweet_actions_usage_hint">Double-tap for actions</string>
+  <string name="tweet_actions_usage_hint">See actions</string>
 
 </resources>


### PR DESCRIPTION
## Problem

It's only possible to set usage hint labels with a resource.

I'd like to be able to set it with a string, so I could construct it at runtime.
## Solution

Add extra APIs and delegate the string resource ones to those.

Also added javadoc to these public API methods and updated the demo now that the bug has been fixed.
## Tests

I attempted to add tests around the delegation of these methods but it would require spying, not sure it's worth it.

![screenshot-2016-10-20_13 38 04 517](https://cloud.githubusercontent.com/assets/2678555/19560802/c5e80730-96cd-11e6-9854-9a5aaa9ca3a6.png)
