### PR TITLE
Move actions parameter from ctor to method

### DIFF
--- a/core/src/main/java/com/novoda/accessibility/ActionsAlertDialogCreator.java
+++ b/core/src/main/java/com/novoda/accessibility/ActionsAlertDialogCreator.java
@@ -8,28 +8,25 @@ import android.support.v7.app.AlertDialog;
 public class ActionsAlertDialogCreator {
 
     private static final int NO_TITLE = 0;
-    
+
     private final Context context;
 
     @StringRes
     private final int title;
 
-    private final Actions actions;
-
-    public ActionsAlertDialogCreator(Context context, Actions actions) {
-        this(context, NO_TITLE, actions);
+    public ActionsAlertDialogCreator(Context context) {
+        this(context, NO_TITLE);
     }
 
-    public ActionsAlertDialogCreator(Context context, @StringRes int title, Actions actions) {
+    public ActionsAlertDialogCreator(Context context, @StringRes int title) {
         this.context = context;
         this.title = title;
-        this.actions = actions;
     }
 
-    public AlertDialog create() {
+    public AlertDialog create(final Actions actions) {
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         builder.setItems(
-                collateActionLabels(),
+                collateActionLabels(actions),
                 new DialogInterface.OnClickListener() {
 
                     @Override
@@ -49,7 +46,7 @@ public class ActionsAlertDialogCreator {
         return builder.create();
     }
 
-    private CharSequence[] collateActionLabels() {
+    private CharSequence[] collateActionLabels(Actions actions) {
         CharSequence[] itemLabels = new CharSequence[actions.getCount()];
         for (int i = 0; i < actions.getCount(); i++) {
             itemLabels[i] = context.getResources().getString(actions.getAction(i).getLabel());

--- a/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
+++ b/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
@@ -29,7 +29,7 @@ public class TweetView extends LinearLayout {
     public TweetView(Context context, AttributeSet attrs) {
         super(context, attrs);
         setOrientation(VERTICAL);
-        actionsAlertDialogCreator = new ActionsAlertDialogCreator(getContext(), R.string.tweet_actions_title);
+        actionsAlertDialogCreator = new ActionsAlertDialogCreator(context, R.string.tweet_actions_title);
     }
 
     @Override

--- a/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
+++ b/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
@@ -41,7 +41,6 @@ public class TweetView extends LinearLayout {
         tweetTextView = (TextView) findViewById(R.id.tweet_text);
         replyButton = findViewById(R.id.tweet_button_reply);
         retweetButton = findViewById(R.id.tweet_button_retweet);
-
     }
 
     public void display(final String tweet, final Listener listener) {

--- a/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
+++ b/demo/src/main/java/com/novoda/accessibility/demo/custom_actions/TweetView.java
@@ -2,6 +2,7 @@ package com.novoda.accessibility.demo.custom_actions;
 
 import android.content.Context;
 import android.support.v4.view.ViewCompat;
+import android.support.v7.app.AlertDialog;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -18,6 +19,8 @@ import java.util.Arrays;
 
 public class TweetView extends LinearLayout {
 
+    private final ActionsAlertDialogCreator actionsAlertDialogCreator;
+
     private TextView tweetTextView;
     private View replyButton;
     private View retweetButton;
@@ -26,6 +29,7 @@ public class TweetView extends LinearLayout {
     public TweetView(Context context, AttributeSet attrs) {
         super(context, attrs);
         setOrientation(VERTICAL);
+        actionsAlertDialogCreator = new ActionsAlertDialogCreator(getContext(), R.string.tweet_actions_title);
     }
 
     @Override
@@ -37,10 +41,11 @@ public class TweetView extends LinearLayout {
         tweetTextView = (TextView) findViewById(R.id.tweet_text);
         replyButton = findViewById(R.id.tweet_button_reply);
         retweetButton = findViewById(R.id.tweet_button_retweet);
+
     }
 
     public void display(final String tweet, final Listener listener) {
-        final Actions actions = createActions(tweet, listener);
+        Actions actions = createActions(tweet, listener);
         ActionsAccessibilityDelegate delegate = new ActionsAccessibilityDelegate(getResources(), actions);
         delegate.setClickLabel(R.string.tweet_actions_usage_hint);
         ViewCompat.setAccessibilityDelegate(this, delegate);
@@ -131,9 +136,8 @@ public class TweetView extends LinearLayout {
     }
 
     private void showAlertDialogFor(Actions actions) {
-        new ActionsAlertDialogCreator(getContext(), R.string.tweet_actions_title, actions)
-                .create()
-                .show();
+        AlertDialog dialog = actionsAlertDialogCreator.create(actions);
+        dialog.show();
     }
 
     public interface Listener {


### PR DESCRIPTION
Fixes #11 

## Problem
The actions dialog creator could have been a static method since it required a new one per usage. This was because the actions were being passed in as a ctor parameter.

## Solution
Move the actions to the `create()` method as a method parameter. This means that the client can reuse the creator for different sets of actions, which is the most common usage in a listview/recyclerview.

Clients will need to update their usage depending on their preference. To reuse the creator:

```
Dialog dialog = new ActionsAlertDialogCreator(context, actions).create();
```

to

```
ActionsAlertDialogCreator dialogCreator = new ActionsAlertDialogCreator(context);
// ...
Dialog dialog = dialogCreator.create(actions);
```

or if they want to create it each time (to avoid keeping it as a field in the View, though there is no state except `Context` which should be fine if you use the View's context):

```
Dialog dialog = new ActionsAlertDialogCreator(context).create(actions);
```

## Tests
No tests added, this is a simple refactor.
