### PR TITLE
Custom hints delegate

### DIFF
--- a/core/src/main/java/com/novoda/accessibility/ActionsAccessibilityDelegate.java
+++ b/core/src/main/java/com/novoda/accessibility/ActionsAccessibilityDelegate.java
@@ -7,56 +7,48 @@ import android.support.v4.view.AccessibilityDelegateCompat;
 import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat;
 import android.view.View;
 
-import static android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.ACTION_CLICK;
-import static android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.ACTION_LONG_CLICK;
-
 public class ActionsAccessibilityDelegate extends AccessibilityDelegateCompat {
 
     private final Resources resources;
     private final Actions actions;
-
-    private CharSequence clickLabel = null;
-    private CharSequence longClickLabel = null;
+    private final UsageHintsAccessibilityDelegate usageHintsAccessibilityDelegate;
 
     public ActionsAccessibilityDelegate(Resources resources, Actions actions) {
+        this(resources, actions, new UsageHintsAccessibilityDelegate(resources));
+    }
+
+    public ActionsAccessibilityDelegate(Resources resources, Actions actions, UsageHintsAccessibilityDelegate usageHintsAccessibilityDelegate) {
         this.resources = resources;
         this.actions = actions;
+        this.usageHintsAccessibilityDelegate = usageHintsAccessibilityDelegate;
     }
 
     /**
      * Label describing the action that will be performed on click
-     *
-     * @param clickLabel
      */
     public void setClickLabel(@StringRes int clickLabel) {
-        setClickLabel(resources.getString(clickLabel));
+        usageHintsAccessibilityDelegate.setClickLabel(clickLabel);
     }
 
     /**
      * Label describing the action that will be performed on click
-     *
-     * @param clickLabel
      */
     public void setClickLabel(CharSequence clickLabel) {
-        this.clickLabel = clickLabel;
+        usageHintsAccessibilityDelegate.setClickLabel(clickLabel);
     }
 
     /**
      * Label describing the action that will be performed on long click
-     *
-     * @param longClickLabel
      */
     public void setLongClickLabel(@StringRes int longClickLabel) {
-        setLongClickLabel(resources.getString(longClickLabel));
+        usageHintsAccessibilityDelegate.setLongClickLabel(longClickLabel);
     }
 
     /**
      * Label describing the action that will be performed on long click
-     *
-     * @param longClickLabel
      */
     public void setLongClickLabel(CharSequence longClickLabel) {
-        this.longClickLabel = longClickLabel;
+        usageHintsAccessibilityDelegate.setLongClickLabel(longClickLabel);
     }
 
     @Override
@@ -67,24 +59,7 @@ public class ActionsAccessibilityDelegate extends AccessibilityDelegateCompat {
             info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(action.getId(), label));
         }
 
-        addCustomDescriptionForClickEventIfNecessary(host, info);
-        addCustomDescriptionForLongClickEventIfNecessary(host, info);
-    }
-
-    private void addCustomDescriptionForClickEventIfNecessary(View host, AccessibilityNodeInfoCompat info) {
-        if (!host.isClickable() || clickLabel == null) {
-            return;
-        }
-
-        info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_CLICK, clickLabel));
-    }
-
-    private void addCustomDescriptionForLongClickEventIfNecessary(View host, AccessibilityNodeInfoCompat info) {
-        if (!host.isLongClickable() || longClickLabel == null) {
-            return;
-        }
-
-        info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_LONG_CLICK, longClickLabel));
+        usageHintsAccessibilityDelegate.onInitializeAccessibilityNodeInfo(host, info);
     }
 
     @Override

--- a/core/src/main/java/com/novoda/accessibility/UsageHintsAccessibilityDelegate.java
+++ b/core/src/main/java/com/novoda/accessibility/UsageHintsAccessibilityDelegate.java
@@ -21,8 +21,6 @@ public class UsageHintsAccessibilityDelegate extends AccessibilityDelegateCompat
 
     /**
      * Label describing the action that will be performed on click
-     *
-     * @param clickLabel
      */
     public void setClickLabel(@StringRes int clickLabel) {
         setClickLabel(resources.getString(clickLabel));
@@ -30,8 +28,6 @@ public class UsageHintsAccessibilityDelegate extends AccessibilityDelegateCompat
 
     /**
      * Label describing the action that will be performed on click
-     *
-     * @param clickLabel
      */
     public void setClickLabel(CharSequence clickLabel) {
         this.clickLabel = clickLabel;
@@ -39,8 +35,6 @@ public class UsageHintsAccessibilityDelegate extends AccessibilityDelegateCompat
 
     /**
      * Label describing the action that will be performed on long click
-     *
-     * @param longClickLabel
      */
     public void setLongClickLabel(@StringRes int longClickLabel) {
         setLongClickLabel(resources.getString(longClickLabel));
@@ -48,8 +42,6 @@ public class UsageHintsAccessibilityDelegate extends AccessibilityDelegateCompat
 
     /**
      * Label describing the action that will be performed on long click
-     *
-     * @param longClickLabel
      */
     public void setLongClickLabel(CharSequence longClickLabel) {
         this.longClickLabel = longClickLabel;

--- a/core/src/main/java/com/novoda/accessibility/UsageHintsAccessibilityDelegate.java
+++ b/core/src/main/java/com/novoda/accessibility/UsageHintsAccessibilityDelegate.java
@@ -9,7 +9,7 @@ import android.view.View;
 import static android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.ACTION_CLICK;
 import static android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.ACTION_LONG_CLICK;
 
-class UsageHintsAccessibilityDelegate extends AccessibilityDelegateCompat {
+public class UsageHintsAccessibilityDelegate extends AccessibilityDelegateCompat {
 
     private final Resources resources;
     private CharSequence clickLabel = null;

--- a/core/src/main/java/com/novoda/accessibility/UsageHintsAccessibilityDelegate.java
+++ b/core/src/main/java/com/novoda/accessibility/UsageHintsAccessibilityDelegate.java
@@ -1,0 +1,82 @@
+package com.novoda.accessibility;
+
+import android.content.res.Resources;
+import android.support.annotation.StringRes;
+import android.support.v4.view.AccessibilityDelegateCompat;
+import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat;
+import android.view.View;
+
+import static android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.ACTION_CLICK;
+import static android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.ACTION_LONG_CLICK;
+
+class UsageHintsAccessibilityDelegate extends AccessibilityDelegateCompat {
+
+    private final Resources resources;
+    private CharSequence clickLabel = null;
+    private CharSequence longClickLabel = null;
+
+    public UsageHintsAccessibilityDelegate(Resources resources) {
+        this.resources = resources;
+    }
+
+    /**
+     * Label describing the action that will be performed on click
+     *
+     * @param clickLabel
+     */
+    public void setClickLabel(@StringRes int clickLabel) {
+        setClickLabel(resources.getString(clickLabel));
+    }
+
+    /**
+     * Label describing the action that will be performed on click
+     *
+     * @param clickLabel
+     */
+    public void setClickLabel(CharSequence clickLabel) {
+        this.clickLabel = clickLabel;
+    }
+
+    /**
+     * Label describing the action that will be performed on long click
+     *
+     * @param longClickLabel
+     */
+    public void setLongClickLabel(@StringRes int longClickLabel) {
+        setLongClickLabel(resources.getString(longClickLabel));
+    }
+
+    /**
+     * Label describing the action that will be performed on long click
+     *
+     * @param longClickLabel
+     */
+    public void setLongClickLabel(CharSequence longClickLabel) {
+        this.longClickLabel = longClickLabel;
+    }
+
+    @Override
+    public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
+        super.onInitializeAccessibilityNodeInfo(host, info);
+
+        addCustomDescriptionForClickEventIfNecessary(host, info);
+        addCustomDescriptionForLongClickEventIfNecessary(host, info);
+    }
+
+    private void addCustomDescriptionForClickEventIfNecessary(View host, AccessibilityNodeInfoCompat info) {
+        if (!host.isClickable() || clickLabel == null) {
+            return;
+        }
+
+        info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_CLICK, clickLabel));
+    }
+
+    private void addCustomDescriptionForLongClickEventIfNecessary(View host, AccessibilityNodeInfoCompat info) {
+        if (!host.isLongClickable() || longClickLabel == null) {
+            return;
+        }
+
+        info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(ACTION_LONG_CLICK, longClickLabel));
+    }
+
+}


### PR DESCRIPTION
Problem:

We had to supply a custom click usage hint "double tap to play movie" but we don't have any custom actions. Previously, we would be required to create an ActionsAccessibilityDelegate with no actions, just to set the usage hint labels, OR duplicate the logic in our app.

Solution:

Extracted a component to set the usage hints, and replace the logic in ActionsAccessibilityDelegate with this extracted component to avoid duplication.

This means we can create the UsageHintsAccessibilityDelegate if we just want to update the usage hints.

Tests:

No tests since the delegate is called from an overridden android method, it's not testable without robolectric/on a device.

