### PR TITLE
Fix close caption manger on KitKat

### DIFF
--- a/core/src/main/java/com/novoda/accessibility/AndroidVersion.java
+++ b/core/src/main/java/com/novoda/accessibility/AndroidVersion.java
@@ -18,4 +18,8 @@ class AndroidVersion {
         return deviceVersion >= Build.VERSION_CODES.KITKAT;
     }
 
+    public boolean isMarshmallowHigher() {
+        return deviceVersion >= Build.VERSION_CODES.M;
+    }
+
 }

--- a/core/src/main/java/com/novoda/accessibility/AndroidVersion.java
+++ b/core/src/main/java/com/novoda/accessibility/AndroidVersion.java
@@ -18,7 +18,7 @@ class AndroidVersion {
         return deviceVersion >= Build.VERSION_CODES.KITKAT;
     }
 
-    public boolean isMarshmallowHigher() {
+    public boolean isMarshmallowOrHigher() {
         return deviceVersion >= Build.VERSION_CODES.M;
     }
 

--- a/core/src/main/java/com/novoda/accessibility/ClosedCaptionManagerFactory.java
+++ b/core/src/main/java/com/novoda/accessibility/ClosedCaptionManagerFactory.java
@@ -16,8 +16,8 @@ class ClosedCaptionManagerFactory {
     }
 
     public CaptionManager createCaptionManager(Context context) {
-        if (androidVersion.isKitKatOrHigher()) {
-            return ClosedCaptionManager.newInstance(context);
+        if (androidVersion.isMarshmallowHigher()) {
+            return ClosedCaptionManagerMarshmallow.newInstance(context);
         } else {
             return new DummyClosedCaptionManager();
         }

--- a/core/src/main/java/com/novoda/accessibility/ClosedCaptionManagerFactory.java
+++ b/core/src/main/java/com/novoda/accessibility/ClosedCaptionManagerFactory.java
@@ -18,6 +18,8 @@ class ClosedCaptionManagerFactory {
     public CaptionManager createCaptionManager(Context context) {
         if (androidVersion.isMarshmallowHigher()) {
             return ClosedCaptionManagerMarshmallow.newInstance(context);
+        } else if (androidVersion.isKitKatOrHigher()) {
+            return ClosedCaptionManagerKitKat.newInstance(context);
         } else {
             return new DummyClosedCaptionManager();
         }

--- a/core/src/main/java/com/novoda/accessibility/ClosedCaptionManagerFactory.java
+++ b/core/src/main/java/com/novoda/accessibility/ClosedCaptionManagerFactory.java
@@ -16,7 +16,7 @@ class ClosedCaptionManagerFactory {
     }
 
     public CaptionManager createCaptionManager(Context context) {
-        if (androidVersion.isMarshmallowHigher()) {
+        if (androidVersion.isMarshmallowOrHigher()) {
             return ClosedCaptionManagerMarshmallow.newInstance(context);
         } else if (androidVersion.isKitKatOrHigher()) {
             return ClosedCaptionManagerKitKat.newInstance(context);

--- a/core/src/main/java/com/novoda/accessibility/ClosedCaptionManagerKitKat.java
+++ b/core/src/main/java/com/novoda/accessibility/ClosedCaptionManagerKitKat.java
@@ -1,0 +1,46 @@
+package com.novoda.accessibility;
+
+import android.annotation.TargetApi;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.os.Build;
+import android.provider.Settings;
+
+public class ClosedCaptionManagerKitKat implements CaptionManager {
+
+    private static final int DISABLED = 0;
+    private static final int ENABLED = 1;
+    private static final String ACCESSIBILITY_CAPTIONING = "accessibility_captioning_enabled";
+
+    private final ContentResolver contentResolver;
+
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    public static CaptionManager newInstance(Context context) {
+        return new ClosedCaptionManagerKitKat(context.getContentResolver());
+    }
+
+    public ClosedCaptionManagerKitKat(ContentResolver contentResolver) {
+        this.contentResolver = contentResolver;
+    }
+
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    @Override
+    public boolean isClosedCaptioningEnabled() {
+        return getCaptionSettingAvailability() == ENABLED;
+    }
+
+    /**
+     * <p>This method implementation was copy/pasted <a href="http://bit.ly/1TILAzT">from the AOSP.</a></p>
+     * <b>Why?</b>
+     * <p>In KitKat devices, when getting the CaptioningManager it creates a Handler without specifying
+     * the Looper. So if you run the getSystemService(CAPTIONING) in a worker thread wich it does not
+     * have any Looper attached it will crash. Since we are only using this to get the status of the
+     * captions in accessibility we opted for copy this code instead of getting the system service and
+     * leave the thread/looper as it is. This was introduced because we needed to run that in a job
+     * scheduler library.</p>
+     */
+    private int getCaptionSettingAvailability() {
+        return Settings.Secure.getInt(contentResolver, ACCESSIBILITY_CAPTIONING, DISABLED);
+    }
+
+}

--- a/core/src/main/java/com/novoda/accessibility/ClosedCaptionManagerKitKat.java
+++ b/core/src/main/java/com/novoda/accessibility/ClosedCaptionManagerKitKat.java
@@ -30,14 +30,11 @@ public class ClosedCaptionManagerKitKat implements CaptionManager {
     }
 
     /**
-     * <p>This method implementation was copy/pasted <a href="http://bit.ly/1TILAzT">from the AOSP.</a></p>
-     * <b>Why?</b>
-     * <p>In KitKat devices, when getting the CaptioningManager it creates a Handler without specifying
-     * the Looper. So if you run the getSystemService(CAPTIONING) in a worker thread wich it does not
-     * have any Looper attached it will crash. Since we are only using this to get the status of the
-     * captions in accessibility we opted for copy this code instead of getting the system service and
-     * leave the thread/looper as it is. This was introduced because we needed to run that in a job
-     * scheduler library.</p>
+     * <p>Copied from AOSP implementation of CaptioningManager</p>
+     * <p>Pre-Marshmallow, querying for CaptioningManager creates a Handler without specifying the Looper.
+     * On worker threads, this causes an exception since it can only be used on the main thread.</p>
+     *
+     * @see <a href="http://bit.ly/1TILAzT">CaptioningManager</a>
      */
     private int getCaptionSettingAvailability() {
         return Settings.Secure.getInt(contentResolver, ACCESSIBILITY_CAPTIONING, DISABLED);

--- a/core/src/main/java/com/novoda/accessibility/ClosedCaptionManagerMarshmallow.java
+++ b/core/src/main/java/com/novoda/accessibility/ClosedCaptionManagerMarshmallow.java
@@ -5,21 +5,21 @@ import android.content.Context;
 import android.os.Build;
 import android.view.accessibility.CaptioningManager;
 
-class ClosedCaptionManager implements CaptionManager {
+class ClosedCaptionManagerMarshmallow implements CaptionManager {
 
     private final CaptioningManager captioningManager;
 
-    @TargetApi(Build.VERSION_CODES.KITKAT)
+    @TargetApi(Build.VERSION_CODES.M)
     public static CaptionManager newInstance(Context context) {
         CaptioningManager captioningManager = (CaptioningManager) context.getSystemService(Context.CAPTIONING_SERVICE);
-        return new ClosedCaptionManager(captioningManager);
+        return new ClosedCaptionManagerMarshmallow(captioningManager);
     }
 
-    ClosedCaptionManager(CaptioningManager captioningManager) {
+    ClosedCaptionManagerMarshmallow(CaptioningManager captioningManager) {
         this.captioningManager = captioningManager;
     }
 
-    @TargetApi(Build.VERSION_CODES.KITKAT)
+    @TargetApi(Build.VERSION_CODES.M)
     @Override
     public boolean isClosedCaptioningEnabled() {
         return captioningManager.isEnabled();

--- a/core/src/test/java/com/novoda/accessibility/ClosedCaptionManagerFactoryTest.java
+++ b/core/src/test/java/com/novoda/accessibility/ClosedCaptionManagerFactoryTest.java
@@ -28,7 +28,7 @@ public class ClosedCaptionManagerFactoryTest {
 
     @Test
     public void givenAndroidVersionMarshmallowOrHigher_whenCreatingANewCaptionManager_thenMarshmallowClosedCaptionManagerReturned() {
-        when(mockAndroidVersion.isMarshmallowHigher()).thenReturn(true);
+        when(mockAndroidVersion.isMarshmallowOrHigher()).thenReturn(true);
 
         CaptionManager captionManager = closedCaptionManagerFactory.createCaptionManager(mockContext);
 

--- a/core/src/test/java/com/novoda/accessibility/ClosedCaptionManagerFactoryTest.java
+++ b/core/src/test/java/com/novoda/accessibility/ClosedCaptionManagerFactoryTest.java
@@ -27,12 +27,21 @@ public class ClosedCaptionManagerFactoryTest {
     }
 
     @Test
-    public void givenAndroidVersionMarshmallowOrHigher_whenCreatingANewCaptionManager_thenClosedCaptionManagerReturned() {
+    public void givenAndroidVersionMarshmallowOrHigher_whenCreatingANewCaptionManager_thenMarshmallowClosedCaptionManagerReturned() {
         when(mockAndroidVersion.isMarshmallowHigher()).thenReturn(true);
 
         CaptionManager captionManager = closedCaptionManagerFactory.createCaptionManager(mockContext);
 
         assertThat(captionManager).isInstanceOf(ClosedCaptionManagerMarshmallow.class);
+    }
+
+    @Test
+    public void givenAndroidVersionKitKatOrHigher_whenCreatingANewCaptionManager_thenKitKatClosedCaptionManagerReturned() {
+        when(mockAndroidVersion.isKitKatOrHigher()).thenReturn(true);
+
+        CaptionManager captionManager = closedCaptionManagerFactory.createCaptionManager(mockContext);
+
+        assertThat(captionManager).isInstanceOf(ClosedCaptionManagerKitKat.class);
     }
 
     @Test

--- a/core/src/test/java/com/novoda/accessibility/ClosedCaptionManagerFactoryTest.java
+++ b/core/src/test/java/com/novoda/accessibility/ClosedCaptionManagerFactoryTest.java
@@ -27,12 +27,12 @@ public class ClosedCaptionManagerFactoryTest {
     }
 
     @Test
-    public void givenAndroidVersionKitKatOrHigher_whenCreatingANewCaptionManager_thenClosedCaptionManagerReturned() {
-        when(mockAndroidVersion.isKitKatOrHigher()).thenReturn(true);
+    public void givenAndroidVersionMarshmallowOrHigher_whenCreatingANewCaptionManager_thenClosedCaptionManagerReturned() {
+        when(mockAndroidVersion.isMarshmallowHigher()).thenReturn(true);
 
         CaptionManager captionManager = closedCaptionManagerFactory.createCaptionManager(mockContext);
 
-        assertThat(captionManager).isInstanceOf(ClosedCaptionManager.class);
+        assertThat(captionManager).isInstanceOf(ClosedCaptionManagerMarshmallow.class);
     }
 
     @Test

--- a/core/src/test/java/com/novoda/accessibility/ClosedCaptionManagerMarshmallowTest.java
+++ b/core/src/test/java/com/novoda/accessibility/ClosedCaptionManagerMarshmallowTest.java
@@ -13,18 +13,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-@TargetApi(Build.VERSION_CODES.KITKAT)
-public class ClosedCaptionManagerTest {
+@TargetApi(Build.VERSION_CODES.M)
+public class ClosedCaptionManagerMarshmallowTest {
 
     @Mock
     CaptioningManager mockCaptioningManager;
 
-    private ClosedCaptionManager closedCaptionManager;
+    private ClosedCaptionManagerMarshmallow closedCaptionManager;
 
     @Before
     public void setUp() {
         initMocks(this);
-        closedCaptionManager = new ClosedCaptionManager(mockCaptioningManager);
+        closedCaptionManager = new ClosedCaptionManagerMarshmallow(mockCaptioningManager);
     }
 
     @Test


### PR DESCRIPTION
We were using `CaptioningManager` to get the status of the close caption starting from KitKat. 
While this is OK when done from the main thread, it will lead to a crash if done from a worker thread.
To solve this we read the relative value from `Settings.Secure`.
The previous approach is fine if used from Marshmallow and later.