### PR TITLE
Add specific checkers for Switch Access service

### DIFF
--- a/core/src/main/java/com/novoda/accessibility/AccessibilityServices.java
+++ b/core/src/main/java/com/novoda/accessibility/AccessibilityServices.java
@@ -28,7 +28,7 @@ public class AccessibilityServices {
     /**
      * Returns true if any accessibility service offering spoken feedback are enabled.
      * <p/>
-     * Be aware this will return true if even TalkBack is suspended, since it's still enabled.
+     * Be aware this will return true even if TalkBack is suspended, since it's still enabled.
      */
     public boolean isSpokenFeedbackEnabled() {
         List<AccessibilityServiceInfo> enabledServices = getEnabledServicesFor(AccessibilityServiceInfo.FEEDBACK_SPOKEN);

--- a/core/src/main/java/com/novoda/accessibility/AccessibilityServices.java
+++ b/core/src/main/java/com/novoda/accessibility/AccessibilityServices.java
@@ -2,10 +2,11 @@ package com.novoda.accessibility;
 
 import android.accessibilityservice.AccessibilityServiceInfo;
 import android.content.Context;
-import android.support.annotation.VisibleForTesting;
 import android.view.accessibility.AccessibilityManager;
 
 import java.util.List;
+
+import static com.novoda.accessibility.Service.SWITCH_ACCESS;
 
 public class AccessibilityServices {
 
@@ -19,16 +20,15 @@ public class AccessibilityServices {
         return new AccessibilityServices(accessibilityManager, captionManager);
     }
 
-    @VisibleForTesting
     AccessibilityServices(AccessibilityManager accessibilityManager, CaptionManager captionManager) {
         this.accessibilityManager = accessibilityManager;
         this.captionManager = captionManager;
     }
 
     /**
-     * Reports if any services offering spoken feedback are enabled.
+     * Returns true if any accessibility service offering spoken feedback are enabled.
      * <p/>
-     * Be aware it will return true when TalkBack is enabled, even if it's suspended.
+     * Be aware this will return true if even TalkBack is suspended, since it's still enabled.
      */
     public boolean isSpokenFeedbackEnabled() {
         List<AccessibilityServiceInfo> enabledServices = getEnabledServicesFor(AccessibilityServiceInfo.FEEDBACK_SPOKEN);
@@ -40,44 +40,26 @@ public class AccessibilityServices {
     }
 
     /**
-     * Reports if video captioning is enabled on the device.
+     * Returns true if video captioning is enabled on the device.
      */
     public boolean isClosedCaptioningEnabled() {
         return captionManager.isClosedCaptioningEnabled();
     }
 
-    public boolean isTalkBackEnabled() {
-        return isKnownServiceEnabled(KnownService.TALKBACK);
-    }
-
+    /**
+     * Returns true if the Switch Access accessibility service is enabled.
+     */
     public boolean isSwitchAccessEnabled() {
-        return isKnownServiceEnabled(KnownService.SWITCH_ACCESS);
+        return isAccessibilityServiceEnabled(SWITCH_ACCESS.qualifiedName());
     }
 
-    public boolean isSelectToSpeakEnabled() {
-        return isKnownServiceEnabled(KnownService.SELECT_TO_SPEAK);
-    }
-
-    private boolean isKnownServiceEnabled(KnownService service) {
+    private boolean isAccessibilityServiceEnabled(String serviceName) {
         List<AccessibilityServiceInfo> enabledServices = getEnabledServicesFor(AccessibilityServiceInfo.FEEDBACK_ALL_MASK);
         for (AccessibilityServiceInfo enabledService : enabledServices) {
-            if (service.qualifiedName.equals(enabledService.getId())) {
+            if (serviceName.equals(enabledService.getId())) {
                 return true;
             }
         }
         return false;
-    }
-
-    private enum KnownService {
-
-        TALKBACK("com.google.android.marvin.talkback/.TalkBackService"),
-        SWITCH_ACCESS("com.google.android.marvin.talkback/com.android.switchaccess.SwitchAccessService"),
-        SELECT_TO_SPEAK("com.google.android.marvin.talkback/com.google.android.accessibility.selecttospeak.SelectToSpeakService");
-
-        private final String qualifiedName;
-
-        KnownService(String qualifiedName) {
-            this.qualifiedName = qualifiedName;
-        }
     }
 }

--- a/core/src/main/java/com/novoda/accessibility/AccessibilityServices.java
+++ b/core/src/main/java/com/novoda/accessibility/AccessibilityServices.java
@@ -50,7 +50,7 @@ public class AccessibilityServices {
      * Returns true if the Switch Access accessibility service is enabled.
      */
     public boolean isSwitchAccessEnabled() {
-        return isAccessibilityServiceEnabled(SWITCH_ACCESS.qualifiedName());
+        return isAccessibilityServiceEnabled(SWITCH_ACCESS.flattenedComponentName());
     }
 
     private boolean isAccessibilityServiceEnabled(String serviceName) {

--- a/core/src/main/java/com/novoda/accessibility/AccessibilityServices.java
+++ b/core/src/main/java/com/novoda/accessibility/AccessibilityServices.java
@@ -45,4 +45,39 @@ public class AccessibilityServices {
     public boolean isClosedCaptioningEnabled() {
         return captionManager.isClosedCaptioningEnabled();
     }
+
+    public boolean isTalkBackEnabled() {
+        return isKnownServiceEnabled(KnownService.TALKBACK);
+    }
+
+    public boolean isSwitchAccessEnabled() {
+        return isKnownServiceEnabled(KnownService.SWITCH_ACCESS);
+    }
+
+    public boolean isSelectToSpeakEnabled() {
+        return isKnownServiceEnabled(KnownService.SELECT_TO_SPEAK);
+    }
+
+    private boolean isKnownServiceEnabled(KnownService service) {
+        List<AccessibilityServiceInfo> enabledServices = getEnabledServicesFor(AccessibilityServiceInfo.FEEDBACK_ALL_MASK);
+        for (AccessibilityServiceInfo enabledService : enabledServices) {
+            if (service.qualifiedName.equals(enabledService.getId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private enum KnownService {
+
+        TALKBACK("com.google.android.marvin.talkback/.TalkBackService"),
+        SWITCH_ACCESS("com.google.android.marvin.talkback/com.android.switchaccess.SwitchAccessService"),
+        SELECT_TO_SPEAK("com.google.android.marvin.talkback/com.google.android.accessibility.selecttospeak.SelectToSpeakService");
+
+        private final String qualifiedName;
+
+        KnownService(String qualifiedName) {
+            this.qualifiedName = qualifiedName;
+        }
+    }
 }

--- a/core/src/main/java/com/novoda/accessibility/Service.java
+++ b/core/src/main/java/com/novoda/accessibility/Service.java
@@ -1,0 +1,23 @@
+package com.novoda.accessibility;
+
+/**
+ * An enumeration of all the known accessibility services and their fully qualified names.
+ * <p>
+ * These are the values returned from android.accessibilityservice.AccessibilityServiceInfo#getId().
+ */
+public enum Service {
+
+    TALKBACK("com.google.android.marvin.talkback/.TalkBackService"),
+    SWITCH_ACCESS("com.google.android.marvin.talkback/com.android.switchaccess.SwitchAccessService"),
+    SELECT_TO_SPEAK("com.google.android.marvin.talkback/com.google.android.accessibility.selecttospeak.SelectToSpeakService");
+
+    private final String qualifiedName;
+
+    Service(String qualifiedName) {
+        this.qualifiedName = qualifiedName;
+    }
+
+    public String qualifiedName() {
+        return qualifiedName;
+    }
+}

--- a/core/src/main/java/com/novoda/accessibility/Service.java
+++ b/core/src/main/java/com/novoda/accessibility/Service.java
@@ -11,13 +11,13 @@ public enum Service {
     SWITCH_ACCESS("com.google.android.marvin.talkback/com.android.switchaccess.SwitchAccessService"),
     SELECT_TO_SPEAK("com.google.android.marvin.talkback/com.google.android.accessibility.selecttospeak.SelectToSpeakService");
 
-    private final String qualifiedName;
+    private final String flattenedComponentName;
 
-    Service(String qualifiedName) {
-        this.qualifiedName = qualifiedName;
+    Service(String flattenedComponentName) {
+        this.flattenedComponentName = flattenedComponentName;
     }
 
-    public String qualifiedName() {
-        return qualifiedName;
+    public String flattenedComponentName() {
+        return flattenedComponentName;
     }
 }

--- a/core/src/main/java/com/novoda/accessibility/Service.java
+++ b/core/src/main/java/com/novoda/accessibility/Service.java
@@ -1,9 +1,12 @@
 package com.novoda.accessibility;
 
+import android.accessibilityservice.AccessibilityServiceInfo;
+import android.content.ComponentName;
+
 /**
- * An enumeration of all the known accessibility services and their fully qualified names.
+ * An enumeration of known accessibility services and their flattened {@link ComponentName}.
  * <p>
- * These are the values returned from android.accessibilityservice.AccessibilityServiceInfo#getId().
+ * These are the values returned from {@link AccessibilityServiceInfo#getId()}.
  */
 public enum Service {
 

--- a/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
+++ b/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
@@ -3,41 +3,27 @@ package com.novoda.accessibility;
 import android.accessibilityservice.AccessibilityServiceInfo;
 import android.view.accessibility.AccessibilityManager;
 
-import java.util.Collections;
-import java.util.List;
-
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 
+import java.util.Collections;
+
+import static android.accessibilityservice.AccessibilityServiceInfo.FEEDBACK_ALL_MASK;
+import static android.accessibilityservice.AccessibilityServiceInfo.FEEDBACK_SPOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 public class AccessibilityServicesTest {
 
-    @Mock
-    AccessibilityManager mockAccessibilityManager;
-
-    @Mock
-    AccessibilityServiceInfo mockAccessibilityServiceInfo;
-
-    @Mock
-    CaptionManager mockCaptionManager;
-
-    private AccessibilityServices accessibilityServices;
-
-    @Before
-    public void setUp() {
-        initMocks(this);
-        accessibilityServices = new AccessibilityServices(mockAccessibilityManager, mockCaptionManager);
-    }
+    private final AccessibilityManager accessibilityManager = mock(AccessibilityManager.class);
+    private final CaptionManager captionManager = mock(CaptionManager.class);
+    private final AccessibilityServices accessibilityServices = new AccessibilityServices(accessibilityManager, captionManager);
 
     @Test
-    public void whenAccessibilityServiceInfoListIsNotEmpty_thenSpokenFeedbackIsEnabled() {
-        List<AccessibilityServiceInfo> serviceInfoList = Collections.singletonList(mockAccessibilityServiceInfo);
-        when(mockAccessibilityManager.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_SPOKEN))
-                .thenReturn(serviceInfoList);
+    public void givenEnabledServicesListForSpokenFeedbackIsNotEmpty_thenReportsSpokenFeedbackIsEnabled() {
+        AccessibilityServiceInfo anyServiceInfo = accessibilityServiceInfoWithId("any");
+        given(accessibilityManager.getEnabledAccessibilityServiceList(FEEDBACK_SPOKEN))
+                .willReturn(Collections.singletonList(anyServiceInfo));
 
         boolean spokenFeedbackEnabled = accessibilityServices.isSpokenFeedbackEnabled();
 
@@ -45,12 +31,29 @@ public class AccessibilityServicesTest {
     }
 
     @Test
-    public void whenAccessibilityServiceInfoListIsEmpty_thenSpokenFeedbackIsDisabled() {
-        when(mockAccessibilityManager.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_SPOKEN))
-                .thenReturn(Collections.<AccessibilityServiceInfo>emptyList());
+    public void givenEnabledServicesListForSpokenFeedbackIsEmpty_thenReportsSpokenFeedbackIsDisabled() {
+        given(accessibilityManager.getEnabledAccessibilityServiceList(FEEDBACK_SPOKEN))
+                .willReturn(Collections.<AccessibilityServiceInfo>emptyList());
 
         boolean spokenFeedbackEnabled = accessibilityServices.isSpokenFeedbackEnabled();
 
         assertThat(spokenFeedbackEnabled).isFalse();
+    }
+
+    @Test
+    public void givenEnabledServicesListIncludesSwitchAccess_thenReportsSwitchAccessIsEnabled() {
+        AccessibilityServiceInfo switchAccessServiceInfo = accessibilityServiceInfoWithId(Service.SWITCH_ACCESS.qualifiedName());
+        given(accessibilityManager.getEnabledAccessibilityServiceList(FEEDBACK_ALL_MASK))
+                .willReturn(Collections.singletonList(switchAccessServiceInfo));
+
+        boolean switchAccessEnabled = accessibilityServices.isSwitchAccessEnabled();
+
+        assertThat(switchAccessEnabled).isTrue();
+    }
+
+    private AccessibilityServiceInfo accessibilityServiceInfoWithId(String id) {
+        AccessibilityServiceInfo serviceInfo = mock(AccessibilityServiceInfo.class);
+        given(serviceInfo.getId()).willReturn(id);
+        return serviceInfo;
     }
 }

--- a/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
+++ b/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
@@ -51,6 +51,17 @@ public class AccessibilityServicesTest {
         assertThat(switchAccessEnabled).isTrue();
     }
 
+    @Test
+    public void givenEnabledServicesListDoesNotIncludeSwitchAccess_thenReportsSwitchAccessIsDisabled() {
+        AccessibilityServiceInfo anyOtherServiceInfo = accessibilityServiceInfoWithId("not switch access");
+        given(accessibilityManager.getEnabledAccessibilityServiceList(FEEDBACK_ALL_MASK))
+                .willReturn(Collections.singletonList(anyOtherServiceInfo));
+
+        boolean switchAccessEnabled = accessibilityServices.isSwitchAccessEnabled();
+
+        assertThat(switchAccessEnabled).isFalse();
+    }
+
     private AccessibilityServiceInfo accessibilityServiceInfoWithId(String id) {
         AccessibilityServiceInfo serviceInfo = mock(AccessibilityServiceInfo.class);
         given(serviceInfo.getId()).willReturn(id);

--- a/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
+++ b/core/src/test/java/com/novoda/accessibility/AccessibilityServicesTest.java
@@ -42,7 +42,7 @@ public class AccessibilityServicesTest {
 
     @Test
     public void givenEnabledServicesListIncludesSwitchAccess_thenReportsSwitchAccessIsEnabled() {
-        AccessibilityServiceInfo switchAccessServiceInfo = accessibilityServiceInfoWithId(Service.SWITCH_ACCESS.qualifiedName());
+        AccessibilityServiceInfo switchAccessServiceInfo = accessibilityServiceInfoWithId(Service.SWITCH_ACCESS.flattenedComponentName());
         given(accessibilityManager.getEnabledAccessibilityServiceList(FEEDBACK_ALL_MASK))
                 .willReturn(Collections.singletonList(switchAccessServiceInfo));
 

--- a/demo/src/main/java/com/novoda/accessibility/demo/AccessibilityServicesActivity.java
+++ b/demo/src/main/java/com/novoda/accessibility/demo/AccessibilityServicesActivity.java
@@ -10,9 +10,7 @@ public class AccessibilityServicesActivity extends AppCompatActivity {
 
     private AccessibilityServices accessibilityServices;
     private TextView spokenFeedback;
-    private TextView talkbackFeedback;
     private TextView switchAccessFeedback;
-    private TextView selectToSpeakFeedback;
     private TextView closedCaptioningStatus;
 
     @Override
@@ -22,9 +20,7 @@ public class AccessibilityServicesActivity extends AppCompatActivity {
 
         accessibilityServices = AccessibilityServices.newInstance(this);
         spokenFeedback = findViewById(R.id.spoken_feedback_service_status);
-        talkbackFeedback = findViewById(R.id.talkback_status);
         switchAccessFeedback = findViewById(R.id.switch_access_status);
-        selectToSpeakFeedback = findViewById(R.id.select_to_speak_status);
         closedCaptioningStatus = findViewById(R.id.closedcaptioning_status);
     }
 
@@ -38,22 +34,10 @@ public class AccessibilityServicesActivity extends AppCompatActivity {
             spokenFeedback.setText("Spoken feedback is not enabled");
         }
 
-        if (accessibilityServices.isTalkBackEnabled()) {
-            talkbackFeedback.setText("TalkBack is enabled");
-        } else {
-            talkbackFeedback.setText("TalkBack is not enabled");
-        }
-
         if (accessibilityServices.isSwitchAccessEnabled()) {
             switchAccessFeedback.setText("Switch Access is enabled");
         } else {
             switchAccessFeedback.setText("Switch Access is not enabled");
-        }
-
-        if (accessibilityServices.isSelectToSpeakEnabled()) {
-            selectToSpeakFeedback.setText("Select To Speak is enabled");
-        } else {
-            selectToSpeakFeedback.setText("Select To Speak is not enabled");
         }
 
         if (accessibilityServices.isClosedCaptioningEnabled()) {

--- a/demo/src/main/java/com/novoda/accessibility/demo/AccessibilityServicesActivity.java
+++ b/demo/src/main/java/com/novoda/accessibility/demo/AccessibilityServicesActivity.java
@@ -9,7 +9,10 @@ import com.novoda.accessibility.AccessibilityServices;
 public class AccessibilityServicesActivity extends AppCompatActivity {
 
     private AccessibilityServices accessibilityServices;
-    private TextView talkbackStatus;
+    private TextView spokenFeedback;
+    private TextView talkbackFeedback;
+    private TextView switchAccessFeedback;
+    private TextView selectToSpeakFeedback;
     private TextView closedCaptioningStatus;
 
     @Override
@@ -18,7 +21,10 @@ public class AccessibilityServicesActivity extends AppCompatActivity {
         setContentView(R.layout.activity_accessibility_checker);
 
         accessibilityServices = AccessibilityServices.newInstance(this);
-        talkbackStatus = findViewById(R.id.talkback_status);
+        spokenFeedback = findViewById(R.id.spoken_feedback_service_status);
+        talkbackFeedback = findViewById(R.id.talkback_status);
+        switchAccessFeedback = findViewById(R.id.switch_access_status);
+        selectToSpeakFeedback = findViewById(R.id.select_to_speak_status);
         closedCaptioningStatus = findViewById(R.id.closedcaptioning_status);
     }
 
@@ -27,9 +33,27 @@ public class AccessibilityServicesActivity extends AppCompatActivity {
         super.onResume();
 
         if (accessibilityServices.isSpokenFeedbackEnabled()) {
-            talkbackStatus.setText("Spoken feedback is enabled");
+            spokenFeedback.setText("Spoken feedback is enabled");
         } else {
-            talkbackStatus.setText("Spoken feedback is not enabled");
+            spokenFeedback.setText("Spoken feedback is not enabled");
+        }
+
+        if (accessibilityServices.isTalkBackEnabled()) {
+            talkbackFeedback.setText("TalkBack is enabled");
+        } else {
+            talkbackFeedback.setText("TalkBack is not enabled");
+        }
+
+        if (accessibilityServices.isSwitchAccessEnabled()) {
+            switchAccessFeedback.setText("Switch Access is enabled");
+        } else {
+            switchAccessFeedback.setText("Switch Access is not enabled");
+        }
+
+        if (accessibilityServices.isSelectToSpeakEnabled()) {
+            selectToSpeakFeedback.setText("Select To Speak is enabled");
+        } else {
+            selectToSpeakFeedback.setText("Select To Speak is not enabled");
         }
 
         if (accessibilityServices.isClosedCaptioningEnabled()) {

--- a/demo/src/main/res/layout/activity_accessibility_checker.xml
+++ b/demo/src/main/res/layout/activity_accessibility_checker.xml
@@ -14,17 +14,7 @@
             android:layout_height="wrap_content" />
 
         <TextView
-            android:id="@+id/talkback_status"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-
-        <TextView
             android:id="@+id/switch_access_status"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-
-        <TextView
-            android:id="@+id/select_to_speak_status"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 

--- a/demo/src/main/res/layout/activity_accessibility_checker.xml
+++ b/demo/src/main/res/layout/activity_accessibility_checker.xml
@@ -1,17 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:orientation="vertical">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-  <TextView
-    android:id="@+id/talkback_status"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
-  <TextView
-    android:id="@+id/closedcaptioning_status"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content" />
+        <TextView
+            android:id="@+id/spoken_feedback_service_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
 
-</LinearLayout>
+        <TextView
+            android:id="@+id/talkback_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/switch_access_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/select_to_speak_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/closedcaptioning_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## This PR

Adds service specific check to determine if the Switch Access a11y service is running.

While previously I've decried trying to design for specific implementations, rather opting to check if a spoken feedback service is enabled (instead of TalkBack for instance), it's not easy with Switch Access. Its feedback type is set to `GENERIC` and using it doesn't disable touch mode, so we aren't able to use `!view.isInTouchMode()` like we could with keyboard usage.

## Approach

The ID of the service is the qualified name. This qualified name is unlikely to change - since changing would have the effect of switching the service off for any user who updates it.

That said, if it is changed, we would have to push an update to this library with the new name (**and the old name**, for backwards compatibility, so exposing a list/iterable). Until then it would report as not enabled.

## Tests

I added a test for testing whether SwitchAccess is enabled/disabled.

## Screenshot

This is with `switch access` and `select to speak` on. Note that `spoken feedback` is reporting as enabled. This is because `select to speak` is a spoken feedback service.

![screenshot_1517168799](https://user-images.githubusercontent.com/2678555/35486497-b810b460-0466-11e8-874d-9e18f04e1a89.png)

Also note this is an outdated screenshot where we had some extra APIs. Decided not to expose these to discourage the use of checking for talkback/select to speak until someone can present a good use-case in the issues (i.e. rely on the `isSpokenFeedbackEnabled()` API).

