### PR TITLE
#30 Deprecate set usage hints instead of deleting

### DIFF
--- a/core/src/main/java/com/novoda/accessibility/ActionsAccessibilityDelegate.java
+++ b/core/src/main/java/com/novoda/accessibility/ActionsAccessibilityDelegate.java
@@ -2,6 +2,7 @@ package com.novoda.accessibility;
 
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.support.annotation.StringRes;
 import android.support.v4.view.AccessibilityDelegateCompat;
 import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat;
 import android.view.View;
@@ -20,6 +21,46 @@ public class ActionsAccessibilityDelegate extends AccessibilityDelegateCompat {
         this.resources = resources;
         this.actions = actions;
         this.usageHints = usageHints;
+    }
+
+    /**
+     * Label describing the action that will be performed on click
+     *
+     * @deprecated Create UsageHints explicitly and pass via the constructor.
+     */
+    @Deprecated
+    public void setClickLabel(@StringRes int clickLabel) {
+        usageHints.setClickLabel(clickLabel);
+    }
+
+    /**
+     * Label describing the action that will be performed on click
+     *
+     * @deprecated Create UsageHints explicitly and pass via the constructor.
+     */
+    @Deprecated
+    public void setClickLabel(CharSequence clickLabel) {
+        usageHints.setClickLabel(clickLabel);
+    }
+
+    /**
+     * Label describing the action that will be performed on long click
+     *
+     * @deprecated Create UsageHints explicitly and pass via the constructor.
+     */
+    @Deprecated
+    public void setLongClickLabel(@StringRes int longClickLabel) {
+        usageHints.setLongClickLabel(longClickLabel);
+    }
+
+    /**
+     * Label describing the action that will be performed on long click
+     *
+     * @deprecated Create UsageHints explicitly and pass via the constructor.
+     */
+    @Deprecated
+    public void setLongClickLabel(CharSequence longClickLabel) {
+        usageHints.setLongClickLabel(longClickLabel);
     }
 
     @Override


### PR DESCRIPTION
This PR adds the deleted methods back to make it easier for people to migrate slower.

It delegates to the UsageHints collaborator but we don't want to have to duplicate these APIs in _every_ AccessibilityDelegate we add, so we move the responsibility of this onto the user, making them provide the UsageHints at ctor time.

Fixes #30